### PR TITLE
Support plugin snapshots like the dependencies

### DIFF
--- a/app/model/DisplayDependency.scala
+++ b/app/model/DisplayDependency.scala
@@ -5,7 +5,7 @@ import utils.VersionComparator
 /**
   * Dependency DTO.
   */
-case class DisplayDependency(name: String, mvnVersion: String) {
+case class DisplayDependency(name: String, centralVersion: String) {
   var versions: Map[String, Set[String]] = Map.empty[String, Set[String]]
 
   def getRepositories(dependency: String): Seq[String] = {
@@ -30,7 +30,7 @@ case class DisplayDependency(name: String, mvnVersion: String) {
     }
     val size = versions.values.flatten.size
     val count = versions
-      .filterKeys(version => VersionComparator.versionCompare(version, mvnVersion) >= 0)
+      .filterKeys(version => VersionComparator.versionCompare(version, centralVersion) >= 0)
       .values.flatten.size
 
     val result = 100d * count / size

--- a/app/model/DisplayPlugin.scala
+++ b/app/model/DisplayPlugin.scala
@@ -5,7 +5,7 @@ import utils.VersionComparator
 /**
   * Dependency DTO.
   */
-case class DisplayPlugin(pluginId: String, projectVersion: String) {
+case class DisplayPlugin(pluginId: String, localVersion: String) {
   var versions: Map[String, Set[String]] = Map.empty[String, Set[String]]
 
   def getRepositories(plugin: String): Seq[String] = {
@@ -30,7 +30,7 @@ case class DisplayPlugin(pluginId: String, projectVersion: String) {
     }
     val size = versions.values.flatten.size
     val count = versions
-      .filterKeys(version => VersionComparator.versionCompare(version, projectVersion) >= 0)
+      .filterKeys(version => VersionComparator.versionCompare(version, localVersion) >= 0)
       .values.flatten.size
 
     val result = 100d * count / size

--- a/app/model/DisplayPlugin.scala
+++ b/app/model/DisplayPlugin.scala
@@ -5,7 +5,7 @@ import utils.VersionComparator
 /**
   * Dependency DTO.
   */
-case class DisplayPlugin(pluginId: String, localVersion: String) {
+case class DisplayPlugin(pluginId: String, gradleVersion: String) {
   var versions: Map[String, Set[String]] = Map.empty[String, Set[String]]
 
   def getRepositories(plugin: String): Seq[String] = {
@@ -30,7 +30,7 @@ case class DisplayPlugin(pluginId: String, localVersion: String) {
     }
     val size = versions.values.flatten.size
     val count = versions
-      .filterKeys(version => VersionComparator.versionCompare(version, localVersion) >= 0)
+      .filterKeys(version => VersionComparator.versionCompare(version, gradleVersion) >= 0)
       .values.flatten.size
 
     val result = 100d * count / size

--- a/app/model/DisplayRepository.scala
+++ b/app/model/DisplayRepository.scala
@@ -9,7 +9,8 @@ import utils.VersionComparator
 case class DisplayRepository(repository: Repository,
                              localDependencies: Map[String, String],
                              centralDependencies: Map[String, String],
-                             localPlugins: Map[String, String]) {
+                             localPlugins: Map[String, String],
+                             gradlePlugins: Map[String, String]) {
 
   val name: String = repository.name
   val repositoryType: String = getRepositoryType(repository.name)
@@ -51,16 +52,18 @@ case class DisplayRepository(repository: Repository,
     * @return True when the plugin is up to date
     */
   def isPluginUpToDate(pluginId: String): Boolean = {
-    val pluginVersion = getPluginVersion(pluginId)
-    val localPluginVersion = getLocalPluginVersion(pluginId)
-    VersionComparator.versionCompare(pluginVersion, localPluginVersion) >= 0
+    val version = getPluginVersion(pluginId)
+    var reference = getGradlePluginVersion(pluginId)
+    if (reference.isEmpty) reference = getLocalPluginVersion(pluginId)
+    VersionComparator.versionCompare(version, reference) >= 0
   }
 
-  def getDependencyVersion(dependency: String): String = repository.versions.getOrElse(dependency, null)
-  def getLocalDependencyVersion(dependency: String): String = localDependencies.getOrElse(dependency, null)
-  def getCentralDependencyVersion(dependency: String): String = centralDependencies.getOrElse(dependency, null)
-  def getPluginVersion(pluginId: String): String = repository.plugins.getOrElse(pluginId, null)
-  def getLocalPluginVersion(pluginId: String): String = localPlugins.getOrElse(pluginId, null)
+  def getDependencyVersion(dependency: String): String = repository.versions.getOrElse(dependency, "")
+  def getLocalDependencyVersion(dependency: String): String = localDependencies.getOrElse(dependency, "")
+  def getCentralDependencyVersion(dependency: String): String = centralDependencies.getOrElse(dependency, "")
+  def getPluginVersion(pluginId: String): String = repository.plugins.getOrElse(pluginId, "")
+  def getLocalPluginVersion(pluginId: String): String = localPlugins.getOrElse(pluginId, "")
+  def getGradlePluginVersion(pluginId: String): String = gradlePlugins.getOrElse(pluginId, "")
   def project(): String = repository.group
 
   implicit class Regex(sc: StringContext) {

--- a/app/services/MavenVersionFetcher.scala
+++ b/app/services/MavenVersionFetcher.scala
@@ -20,7 +20,7 @@ class MavenVersionFetcher {
   val pattern: Regex = """([^:]+):(.+)""".r
 
   // download maven-metadata to get the latest repository
-  def getLatestMvnVersion(name: String, mavenUrl: String, mavenUser: String, mavenPassword: String): Future[(String, String)] = Future {
+  def getLatestVersion(name: String, mavenUrl: String, mavenUser: String, mavenPassword: String): Future[(String, String)] = Future {
 
     var uri: String = null
     try {

--- a/app/services/VersionService.scala
+++ b/app/services/VersionService.scala
@@ -20,8 +20,12 @@ class VersionService @Inject()(configuration: Configuration, fetcher: MavenVersi
                                gitRepositoryService: GitRepositoryService, springBootVersionService: SpringBootVersionService) {
 
   private val filePath = configuration.get("project.repositories.path")
-  private val ekinoMavenUrl = configuration.get("maven.repository.url")
+  private val localMavenUrl = configuration.get("local.maven.url")
+  private val localMavenUser = configuration.getOptional("local.maven.user").getOrElse("")
+  private val localMavenPassword = configuration.getOptional("local.maven.password").getOrElse("")
   private val centralMavenUrl = configuration.get("central.maven.url")
+  private val centralMavenUser = configuration.getOptional("central.maven.user").getOrElse("")
+  private val centralMavenPassword = configuration.getOptional("central.maven.password").getOrElse("")
 
   private var repositories = Seq.empty[Repository]
   private var dependencies = Seq.empty[DisplayDependency]
@@ -222,10 +226,10 @@ class VersionService @Inject()(configuration: Configuration, fetcher: MavenVersi
           mergedValues += v._1 -> v._2
         }
         if (mvnProjectFutures.get(v._1).isEmpty) {
-          mvnProjectFutures += v._1 -> fetcher.getLatestMvnVersion(v._1, ekinoMavenUrl)
+          mvnProjectFutures += v._1 -> fetcher.getLatestMvnVersion(v._1, localMavenUrl, localMavenUser, localMavenPassword)
         }
         if (mvnCentralFutures.get(v._1).isEmpty) {
-          mvnCentralFutures += v._1 -> fetcher.getLatestMvnVersion(v._1, centralMavenUrl)
+          mvnCentralFutures += v._1 -> fetcher.getLatestMvnVersion(v._1, centralMavenUrl, centralMavenUser, centralMavenPassword)
         }
       })
     )

--- a/app/views/dependency.scala.html
+++ b/app/views/dependency.scala.html
@@ -19,7 +19,7 @@
                 }
             </h1>
             <h3>
-                <span>Latest Maven Release : </span> <span>@dependency.mvnVersion</span>
+                <span>Latest Maven Release : </span> <span>@dependency.centralVersion</span>
             </h3>
             <div class="pull-right return-block">
                 <a class="btn btn-primary" href="@routes.HomeController.index()" role="button">Return to home</a>

--- a/app/views/dependency.scala.html
+++ b/app/views/dependency.scala.html
@@ -19,7 +19,7 @@
                 }
             </h1>
             <h3>
-                <span>Latest Maven Release : </span> <span>@dependency.centralVersion</span>
+                <span>Latest release: </span> <span>@dependency.centralVersion</span>
             </h3>
             <div class="pull-right return-block">
                 <a class="btn btn-primary" href="@routes.HomeController.index()" role="button">Return to home</a>

--- a/app/views/plugin.scala.html
+++ b/app/views/plugin.scala.html
@@ -18,6 +18,9 @@
                     <span data-color="@completionPercentage" class="pull-right label">@completionPercentage %</span>
                 }
             </h1>
+            <h3>
+                <span>Latest release: </span> <span>@plugin.gradleVersion</span>
+            </h3>
             <div class="pull-right return-block">
                 <a class="btn btn-primary" href="@routes.HomeController.index()" role="button">Return to home</a>
             </div>

--- a/app/views/repository.scala.html
+++ b/app/views/repository.scala.html
@@ -70,6 +70,7 @@
                             <th>Name</th>
                             <th>Current version</th>
                             <th>Latest version used</th>
+                            <th>Latest release</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -85,6 +86,7 @@
                             </td>
                             <td>@repository.getPluginVersion(pluginId)</td>
                             <td>@repository.getLocalPluginVersion(pluginId)</td>
+                            <td>@repository.getGradlePluginVersion(pluginId)</td>
                         </tr>
                     }
                     </tbody>

--- a/app/views/repository.scala.html
+++ b/app/views/repository.scala.html
@@ -34,8 +34,8 @@
                         <tr>
                             <th>Name</th>
                             <th>Current version</th>
-                            <th>Latest version in project</th>
-                            <th>Latest Maven release</th>
+                            <th>Latest version used</th>
+                            <th>Latest release</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -52,9 +52,9 @@
                                     <span class="pull-right glyphicon glyphicon-ok" ></span>
                                 }
                             </td>
-                            <td>@repository.getVersion(version)</td>
-                            <td>@repository.getProjectVersion(version)</td>
-                            <td>@repository.getMvnVersion(version)</td>
+                            <td>@repository.getDependencyVersion(version)</td>
+                            <td>@repository.getLocalDependencyVersion(version)</td>
+                            <td>@repository.getCentralDependencyVersion(version)</td>
                         </tr>
                     }
                     </tbody>
@@ -69,7 +69,7 @@
                         <tr>
                             <th>Name</th>
                             <th>Current version</th>
-                            <th>Latest version in project</th>
+                            <th>Latest version used</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -84,7 +84,7 @@
                                 }
                             </td>
                             <td>@repository.getPluginVersion(pluginId)</td>
-                            <td>@repository.getProjectPluginVersion(pluginId)</td>
+                            <td>@repository.getLocalPluginVersion(pluginId)</td>
                         </tr>
                     }
                     </tbody>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -21,3 +21,7 @@ central.maven.url = "https://repo.maven.apache.org/maven2/"
 local.maven.url = ${?LOCAL_REPOSITORY_URL}
 local.maven.user = ${?LOCAL_REPOSITORY_USER}
 local.maven.password = ${?LOCAL_REPOSITORY_PASSWORD}
+gradle-plugins.maven.url = "https://plugins.gradle.org/m2/"
+local-plugins.maven.url = ${?LOCAL_REPOSITORY_URL}
+local-plugins.maven.user = ${?LOCAL_REPOSITORY_USER}
+local-plugins.maven.password = ${?LOCAL_REPOSITORY_PASSWORD}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -18,6 +18,6 @@ gitlab.ignored.repository = []
 
 # maven data
 central.maven.url = "https://repo.maven.apache.org/maven2/"
-maven.repository.url = ${?EKINO_REPOSITORY_URL}
-maven.repository.user = ${?EKINO_REPOSITORY_USER}
-maven.repository.password = ${?EKINO_REPOSITORY_PASSWORD}
+local.maven.url = ${?LOCAL_REPOSITORY_URL}
+local.maven.user = ${?LOCAL_REPOSITORY_USER}
+local.maven.password = ${?LOCAL_REPOSITORY_PASSWORD}

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,5 +9,5 @@ scala.version = 2.12
 
 # Versions of dependencies
 slf4j-simple.version = 1.7.25
-org.eclipse.jgit.version = 4.11.0.201803080745-r
+org.eclipse.jgit.version = 5.0.3.201809091024-r
 scalatestplus-play_2.12.version = 3.1.2


### PR DESCRIPTION
The modifications treat the plugins like the dependencies:
  - The last release is retrieved
  - Snapshots can be used (when using Gradle 4.10+)