### PR TITLE
Allow authentication on the NPM registry

### DIFF
--- a/app/model/Config.scala
+++ b/app/model/Config.scala
@@ -5,7 +5,7 @@ import play.api.Configuration
 
 case class Config(conf: Configuration) {
   val filePath: String = conf.get("project.repositories.path")
-  val npmRegistryUrl: String = conf.get("npm.registry.url")
+  val npmRegistry = Site(conf.get[Configuration]("npm.registry"))
   val mavenLocal = Site(conf.get[Configuration]("maven.local"))
   val mavenLocalPlugins = Site(conf.get[Configuration]("maven.local-plugins"))
   val mavenCentral = Site(conf.get[Configuration]("maven.central"))

--- a/app/services/HttpBasicAuth.scala
+++ b/app/services/HttpBasicAuth.scala
@@ -1,0 +1,14 @@
+package services
+
+import java.util.Base64
+
+object HttpBasicAuth {
+  val BASIC = "Basic"
+  val AUTHORIZATION = "Authorization"
+
+  def getHeader(username: String, password: String): String =
+    BASIC + " " + encodeCredentials(username, password)
+
+  def encodeCredentials(username: String, password: String): String =
+    new String(Base64.getEncoder.encode((username + ":" + password).getBytes))
+}

--- a/app/services/MavenVersionFetcher.scala
+++ b/app/services/MavenVersionFetcher.scala
@@ -2,7 +2,6 @@ package services
 
 import java.io.FileNotFoundException
 import java.net.URL
-import java.util.Base64
 
 import model.CustomExecutionContext.executionContextExecutor
 import model.Site
@@ -61,16 +60,5 @@ object MavenVersionFetcher {
       case pattern(_, _) => true
       case _             => false
     }
-
-  object HttpBasicAuth {
-    val BASIC = "Basic"
-    val AUTHORIZATION = "Authorization"
-
-    def getHeader(username: String, password: String): String =
-      BASIC + " " + encodeCredentials(username, password)
-
-    def encodeCredentials(username: String, password: String): String =
-      new String(Base64.getEncoder.encode((username + ":" + password).getBytes))
-  }
 
 }

--- a/app/services/VersionService.scala
+++ b/app/services/VersionService.scala
@@ -173,7 +173,7 @@ class VersionService @Inject()(
 
     val localDependencyFutures = dependencies.keys.filter(MavenVersionFetcher.isMavenVersion).map(MavenVersionFetcher.getLatestVersion(_, config.mavenLocal))
     val centralDependencyFutures = dependencies.keys.filter(MavenVersionFetcher.isMavenVersion).map(MavenVersionFetcher.getLatestVersion(_, config.mavenCentral))
-    val npmDependencyFutures = dependencies.keys.filter(!MavenVersionFetcher.isMavenVersion(_)).map(NpmVersionFetcher.getLatestVersion(_, config.npmRegistryUrl))
+    val npmDependencyFutures = dependencies.keys.filter(!MavenVersionFetcher.isMavenVersion(_)).map(NpmVersionFetcher.getLatestVersion(_, config.npmRegistry))
 
     val list = FutureHelper.await[(String, String)](centralDependencyFutures ++ localDependencyFutures ++ npmDependencyFutures, configuration, "timeout.compute-plugins")
 


### PR DESCRIPTION
This is useful when using a local proxy/cache, such as Nexus.