### PR TITLE
Fixes for the initialization and update of the repositories

### DIFF
--- a/app/services/VersionService.scala
+++ b/app/services/VersionService.scala
@@ -22,7 +22,7 @@ class VersionService @Inject()(
   private val springBootMasterData = springBootVersionService.computeSpringBootData(true)
   private val parsers = Seq(NPMRepositoryParser, GradleRepositoryParser, MavenRepositoryParser, SBTRepositoryParser)
 
-  private var data: RepositoryData = RepositoryData.noData
+  @volatile private var data: RepositoryData = RepositoryData.noData
 
   /**
     * List all the projects to display.


### PR DESCRIPTION
When using sub-groups with Gitlab, the repositories are not seen because they are not 2nd-level directories in the workspace : so, instead of hardcoding the depth, the tree is descended until files are found in the current directory, meaning it's an actual repository.

The initialization becomes asynchronous, like the update (if configured that way), so that the home page can respond instantly, even if it returns empty.