### PR TITLE
Handle empty dependencies in the parsers

### DIFF
--- a/app/utils/NPMRepositoryParser.scala
+++ b/app/utils/NPMRepositoryParser.scala
@@ -18,7 +18,9 @@ object NPMRepositoryParser extends AbstractParser {
     // project files
     val buildFiles = getBuildFiles(folder)
 
-    val dependencies = buildFiles.map(getDependencies(_, folder)).reduce((d1, d2) => d1 ++ d2)
+    val dependencies = buildFiles
+      .map(getDependencies(_, folder))
+      .fold(Seq.empty[Dependency])((d1, d2) => d1 ++ d2)
 
     Repository(folder.getName, groupName, dependencies, "NPM", Seq.empty[Plugin])
   }

--- a/app/utils/YarnLockRepositoryParser.scala
+++ b/app/utils/YarnLockRepositoryParser.scala
@@ -16,7 +16,9 @@ object YarnLockRepositoryParser extends AbstractParser {
     // project files
     val buildFiles = getBuildFiles(folder)
 
-    val dependencies = buildFiles.map(getDependencies(_, folder, groupName)).reduce((d1, d2) => d1 ++ d2)
+    val dependencies = buildFiles
+      .map(getDependencies(_, folder, groupName))
+      .fold(Seq.empty[Dependency])((d1, d2) => d1 ++ d2)
 
     Repository(folder.getName, groupName, dependencies, "Yarn", Seq.empty)
   }


### PR DESCRIPTION
The `TraversableOnce#reduce` method does not accept empty sequences. Seems like it is possible to have an empty sequence of dependencies 😛 