### PR TITLE
[BUGFIX] Sort the dependencies by subfolder and name

### DIFF
--- a/app/services/VersionService.scala
+++ b/app/services/VersionService.scala
@@ -123,14 +123,14 @@ class VersionService @Inject()(configuration: Configuration,
     parsers
       .filter(_.canProcess(projectFolder))
       .map(_.buildRepository(projectFolder, projectFolder.getParentFile.getName, springBootDefaultData, springBootMasterData))
-      .reduceOption((r1, r2) => Repository(
-        r1.name,
-        r1.group,
-        r1.dependencies ++ r2.dependencies,
-        r1.toolVersion + "/" + r2.toolVersion,
-        r1.plugins ++ r2.plugins
-      ))
+      .reduceOption((r1, r2) => r1.copy(
+        dependencies = r1.dependencies ++ r2.dependencies,
+        toolVersion = r1.toolVersion + "/" + r2.toolVersion,
+        plugins = r1.plugins ++ r2.plugins))
       .filter(repo => repo.dependencies.nonEmpty || repo.plugins.nonEmpty)
+      .map(r => r.copy(
+        dependencies = r.dependencies.sortBy(d => (d.subfolder, d.getType, d.name)),
+        plugins = r.plugins.sortBy(p => (p.getType, p.name))))
   }
 
   /**


### PR DESCRIPTION
Without a global sort, a multi-build-tool project displays the dependencies
per build tool, which mixes badly if there are multiple modules: the content
of the root module of the second build tool appears with the content of the
last module of the first build tool.