### PR TITLE
[FEATURE] springboot data now use the springboot project version

### DIFF
--- a/app/controllers/RepositoryController.scala
+++ b/app/controllers/RepositoryController.scala
@@ -14,7 +14,7 @@ class RepositoryController @Inject()(versionService: VersionService) extends Inj
   def index(name: String): Action[AnyContent] = Action { implicit request =>
     versionService.getRepository(name) match {
       case Some(repository) =>
-        val springBootData = SpringBootUtils.getSpringBootData(repository.repository.plugins, versionService.data.springBootDefaultData, versionService.data.springBootMasterData)
+        val springBootData = SpringBootUtils.getSpringBootData(repository.repository.plugins)
         render {
           case Accepts.Json() => Ok(Json.toJson(repository))
           case _              => Ok(views.html.repository(repository, springBootData))

--- a/app/model/RepositoryData.scala
+++ b/app/model/RepositoryData.scala
@@ -10,9 +10,7 @@ case class RepositoryData(
   localDependencies: Map[String, String],
   centralDependencies: Map[String, String],
   localPlugins: Map[String, String],
-  gradlePlugins: Map[String, String],
-  springBootDefaultData: SpringBootData,
-  springBootMasterData: SpringBootData
+  gradlePlugins: Map[String, String]
 ) {
 
   def getPluginsAndDependencies: Seq[AbstractDisplay] = {
@@ -28,8 +26,6 @@ object RepositoryData {
     Map.empty[String, String],
     Map.empty[String, String],
     Map.empty[String, String],
-    Map.empty[String, String],
-    SpringBootData.noData,
-    SpringBootData.noData
+    Map.empty[String, String]
   )
 }

--- a/app/utils/AbstractParser.scala
+++ b/app/utils/AbstractParser.scala
@@ -33,7 +33,7 @@ abstract class AbstractParser {
   def canProcess(repository: File): Boolean =
     getBuildFiles(repository).exists(_.exists())
 
-  def buildRepository(folder: File, groupName: String, springBootDefaultData: SpringBootData, springBootMasterData: SpringBootData): Repository
+  def buildRepository(folder: File, groupName: String): Repository
 
   // read a file and extract lines matching a pattern
   protected def extractFromFile[T](file: File, regex: Regex, extract: ExtractGroups[T]): Map[String, T] = {

--- a/app/utils/MavenRepositoryParser.scala
+++ b/app/utils/MavenRepositoryParser.scala
@@ -20,7 +20,7 @@ object MavenRepositoryParser extends AbstractParser {
   val mavenVersionRegex: Regex = """.*apache-maven-([0-9.-]+)-.*""".r
   val pluginRegex: Regex = """\s*<plugin>\n\s*<groupId>([a-zA-Z0-9.-]+)</groupId>\n\s*<artifactId>([a-zA-Z0-9.-]+)</artifactId>\n\s*<version>(?:\$\{)?([a-zA-Z0-9.-]+)(\})?</version>""".r
 
-  override def buildRepository(folder: File, groupName: String, springBootDefaultData: SpringBootData, springBootMasterData: SpringBootData): Repository = {
+  override def buildRepository(folder: File, groupName: String): Repository = {
     // project files
     val repositoryPath = folder.getPath
     val buildFiles = getBuildFiles(folder)
@@ -29,13 +29,13 @@ object MavenRepositoryParser extends AbstractParser {
     val mavenVersion = extractFromFile(new File(repositoryPath, mavenWrapperFileName), mavenVersionRegex, extractValue).getOrElse("value", "")
 
     val dependencies = buildFiles
-      .map(getDependencies(_, folder, springBootDefaultData, springBootMasterData, defaultProperties))
+      .map(getDependencies(_, folder, defaultProperties))
       .reduce((r1, r2) => (r1._1 ++ r2._1, r1._2 ++ r2._2))
 
     Repository(folder.getName, groupName, dependencies._1, s"Maven $mavenVersion", dependencies._2)
   }
 
-  private def getDependencies(buildFile: File, folder: File, springBootDefaultData: SpringBootData, springBootMasterData: SpringBootData, defaultProperties: Map[String, String]): (Seq[Dependency], Seq[Plugin]) = {
+  private def getDependencies(buildFile: File, folder: File, defaultProperties: Map[String, String]): (Seq[Dependency], Seq[Plugin]) = {
     val subfolder = getSubfolder(buildFile, folder)
     val otherProperties = extractFromFile(buildFile, propertyRegex, extractProperties)
     val properties = defaultProperties ++ otherProperties
@@ -49,7 +49,7 @@ object MavenRepositoryParser extends AbstractParser {
       .map(p => MavenPlugin(p._1, p._2))
       .toSeq
 
-    val springBootData = SpringBootUtils.getSpringBootData(plugins, springBootDefaultData, springBootMasterData)
+    val springBootData = SpringBootUtils.getSpringBootData(plugins)
     val springBootOverrides = SpringBootUtils.getSpringBootOverrides(artifacts, properties, springBootData)
       .map(p => JvmDependency(p._1, p._2, subfolder))
       .toSeq

--- a/app/utils/NPMRepositoryParser.scala
+++ b/app/utils/NPMRepositoryParser.scala
@@ -16,7 +16,7 @@ object NPMRepositoryParser extends AbstractParser {
   private val lockFileName = "package-lock.json"
   private val npmVersion = """[~<>=v^]*(.*)""".r
 
-  override def buildRepository(folder: File, groupName: String, springBootDefaultData: SpringBootData, springBootMasterData: SpringBootData): Repository = {
+  override def buildRepository(folder: File, groupName: String): Repository = {
     // project files
     val buildFiles = getBuildFiles(folder)
 

--- a/app/utils/SBTRepositoryParser.scala
+++ b/app/utils/SBTRepositoryParser.scala
@@ -20,7 +20,7 @@ object SBTRepositoryParser extends AbstractParser {
   val scala2Regex: Regex = """(2.\d+).*""".r
   private val logger = Logger(SBTRepositoryParser.getClass)
 
-  override def buildRepository(folder: File, groupName: String, springBootDefaultData: SpringBootData, springBootMasterData: SpringBootData): Repository = {
+  override def buildRepository(folder: File, groupName: String): Repository = {
     // project files
     val buildFile = getBuildFiles(folder).head
 

--- a/app/utils/SpringBootUtils.scala
+++ b/app/utils/SpringBootUtils.scala
@@ -1,6 +1,7 @@
 package utils
 
-import model.{Plugin, SpringBootData, Dependency}
+import model.{Dependency, Plugin, SpringBootData}
+import services.SpringBootVersionService
 
 import scala.collection.immutable.ListMap
 
@@ -25,12 +26,11 @@ object SpringBootUtils {
     result.result()
   }
 
-  def getSpringBootData(plugins: Seq[Plugin], springBootDefaultData: SpringBootData, springBootMasterData: SpringBootData): SpringBootData = {
+  def getSpringBootData(plugins: Seq[Plugin]): SpringBootData = {
     plugins
       .find(_.name.contains("org.springframework.boot"))
-      .filter(_.name.startsWith("1."))
-      .map(_ => springBootDefaultData)
-      .getOrElse(springBootMasterData)
+      .map(plugin => SpringBootVersionService.springBootData(plugin.version))
+      .getOrElse(SpringBootData.noData)
   }
 
 }

--- a/app/utils/YarnLockRepositoryParser.scala
+++ b/app/utils/YarnLockRepositoryParser.scala
@@ -16,7 +16,7 @@ object YarnLockRepositoryParser extends AbstractParser {
   private val versionValue = """[.\da-zA-Z-]+""".r
   val extractYarnDependency: ExtractGroups[YarnDependency] = matchData => matchData.group(1) -> YarnDependency(matchData.group(3), matchData.group(2))
 
-  override def buildRepository(folder: File, groupName: String, springBootDefaultData: SpringBootData, springBootMasterData: SpringBootData): Repository = {
+  override def buildRepository(folder: File, groupName: String): Repository = {
     // project files
     val buildFiles = getBuildFiles(folder)
 
@@ -30,7 +30,7 @@ object YarnLockRepositoryParser extends AbstractParser {
   private def getDependencies(buildFile: File, folder: File, groupName: String): Seq[Dependency] = {
     val subfolder = getSubfolder(buildFile, folder)
 
-    val npmArtifacts: Seq[Dependency] = NPMRepositoryParser.buildRepository(buildFile.getParentFile, groupName, SpringBootData.noData, SpringBootData.noData)
+    val npmArtifacts: Seq[Dependency] = NPMRepositoryParser.buildRepository(buildFile.getParentFile, groupName)
       .dependencies
 
     extractFromFile(buildFile, yarnVersion, extractYarnDependency)

--- a/app/views/repository.scala.html
+++ b/app/views/repository.scala.html
@@ -51,18 +51,20 @@
                                 <th colspan="4" class="repository"><span class="default"> @dependency.subfolder</span></th>
                             }
                             <tr>
-                                <td class="@repository.springBootVersion(dependency, springBootData)">
-                                    <span class="small-image"><img src="@routes.Assets.at(utils.ImageHelper.getIconPath(dependency.getType))" alt="image"></span>
-                                    <a href="@routes.DependencyController.dependency(dependency.name)" role="button">
-                                        <span>@dependency.name</span>
-                                    </a>
-                                    @if(repository.springBootVersion(dependency, springBootData) != "") {
-                                        <span class="small-image"><img src="@routes.Assets.at("images/" + repository.springBootVersion(dependency, springBootData) + ".svg")"></span>
-                                    }
-                                    @if(repository.isVersionUpToDate(dependency)) {
-                                        <span class="badge badge-pill badge-success badge-table float-right">OK</span>
-                                    }
-                                </td>
+                                @defining(repository.springBootVersion(dependency, springBootData)) { springBoot: String =>
+                                    <td class="@springBoot">
+                                        <span class="small-image"><img src="@routes.Assets.at(utils.ImageHelper.getIconPath(dependency.getType))" alt="image"></span>
+                                        <a href="@routes.DependencyController.dependency(dependency.name)" role="button">
+                                            <span>@dependency.name</span>
+                                        </a>
+                                        @if(springBoot != "") {
+                                            <span class="small-image"><img src="@routes.Assets.at("images/" + springBoot + ".svg")" alt="@springBoot"></span>
+                                        }
+                                        @if(repository.isVersionUpToDate(dependency)) {
+                                            <span class="badge badge-pill badge-success badge-table float-right">OK</span>
+                                        }
+                                    </td>
+                                }
                                 <td>@dependency.version</td>
                                 <td>@repository.getLocalDependencyVersion(dependency.name)</td>
                                 <td>@repository.getCentralDependencyVersion(dependency.name)</td>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -13,10 +13,6 @@ play {
 }
 
 github {
-  springboot {
-    url = "https://raw.githubusercontent.com/spring-projects/spring-boot/1.5.x/spring-boot-dependencies/pom.xml"
-    master-url = "https://raw.githubusercontent.com/spring-projects/spring-boot/master/spring-boot-project/spring-boot-dependencies/pom.xml"
-  }
   user = ${?GITHUB_USER}
   token = ${?GITHUB_TOKEN}
   users = ${?GITHUB_USERS}
@@ -62,8 +58,4 @@ npm {
 scheduler {
   initial-delay = 1 minute
   interval = 1 day
-}
-
-timeout {
-  clear-cache = 10 minute
 }


### PR DESCRIPTION
Instead of using `master` and `1.5.x` branches to resolve springboot overrides, the springboot plugin version of the project is now used.
The springboot data is cached using [scalaz Memo](http://fasihkhatib.com/2017/08/05/scalaz-memo/) 