### PR TITLE
Arrange the dependencies and plugins version in descending order

### DIFF
--- a/app/views/dependency.scala.html
+++ b/app/views/dependency.scala.html
@@ -38,7 +38,7 @@
                         </tr>
                     </thead>
                     <tbody>
-                    @for(version <- dependency.versions.keys.toSeq.sorted(utils.VersionComparator)) {
+                    @for(version <- dependency.versions.keys.toSeq.sorted(utils.VersionComparator.reverse)) {
                         <tr>
                             <td>@version</td>
                             <td>

--- a/app/views/plugin.scala.html
+++ b/app/views/plugin.scala.html
@@ -38,7 +38,7 @@
                         </tr>
                     </thead>
                     <tbody>
-                    @for(version <- plugin.versions.keys.toSeq.sorted(utils.VersionComparator)) {
+                    @for(version <- plugin.versions.keys.toSeq.sorted(utils.VersionComparator.reverse)) {
                         <tr>
                             <td>@version</td>
                             <td>


### PR DESCRIPTION
This was a small regression introduced in https://github.com/ekino/ekino-tools-version/commit/6ad9a6af0d1c73b0525239451c57dd0bff74c4bf