### PR TITLE
[BUGFIX] Support other NPM registries than the public one

### DIFF
--- a/app/services/NpmVersionFetcher.scala
+++ b/app/services/NpmVersionFetcher.scala
@@ -16,7 +16,7 @@ import scala.util.control.NonFatal
 object NpmVersionFetcher extends VersionFetcher {
 
   val ACCEPT = "Accept"
-  val NPM_JSON = "application/vnd.npm.install-v1+json"
+  val NPM_JSON = "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*"
   val DIST_TAGS = "dist-tags"
   val LATEST = "latest"
   private val logger = Logger(NpmVersionFetcher.getClass)


### PR DESCRIPTION
For example, when using a proxy such as Artifactory, using the specific
content type only won't work, so providing alternatives is useful.